### PR TITLE
sc-134006 use dev target and minor tweaks 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,16 +6,27 @@ remote_url=`git config --get remote.origin.url`
 last_commit_id=`git rev-parse HEAD`
 
 
-plugin:
+dist-clean:
+	rm -rf dist
+
+plugin: dist-clean
 	@echo "[START] Archiving plugin to dist/ folder..."
 	@cat plugin.json | json_pp > /dev/null
-	@rm -rf dist
 	@mkdir dist
 	@echo "{\"remote_url\":\"${remote_url}\",\"last_commit_id\":\"${last_commit_id}\"}" > release_info.json
 	@git archive -v -9 --format zip -o dist/${archive_file_name} HEAD
-	@zip --delete dist/${archive_file_name} "tests/*"
+	@if [[ -d tests ]]; then \
+		zip --delete dist/${archive_file_name} "tests/*"; \
+	fi
 	@zip -u dist/${archive_file_name} release_info.json
 	@rm release_info.json
+	@echo "[SUCCESS] Archiving plugin to dist/ folder: Done!"
+
+dev: dist-clean
+	@echo "[START] Archiving plugin to dist/ folder... (dev mode)"
+	@cat plugin.json | json_pp > /dev/null
+	@mkdir dist
+	@zip -v -9 dist/${archive_file_name} -r . --exclude "tests/*"
 	@echo "[SUCCESS] Archiving plugin to dist/ folder: Done!"
 
 unit-tests:
@@ -48,6 +59,3 @@ integration-tests:
 	)
 
 tests: unit-tests integration-tests
-
-dist-clean:
-	rm -rf dist

--- a/Makefile
+++ b/Makefile
@@ -7,9 +7,6 @@ last_commit_id=`git rev-parse HEAD`
 
 .DEFAULT_GOAL := plugin
 
-dist-clean:
-	rm -rf dist
-
 plugin: dist-clean
 	@echo "[START] Archiving plugin to dist/ folder..."
 	@cat plugin.json | json_pp > /dev/null
@@ -27,7 +24,7 @@ dev: dist-clean
 	@echo "[START] Archiving plugin to dist/ folder... (dev mode)"
 	@cat plugin.json | json_pp > /dev/null
 	@mkdir dist
-	@zip -v -9 dist/${archive_file_name} -r . --exclude "tests/*" "env/*"
+	@zip -v -9 dist/${archive_file_name} -r . --exclude "tests/*" "env/*" ".git/*" ".pytest_cache/*"
 	@echo "[SUCCESS] Archiving plugin to dist/ folder: Done!"
 
 unit-tests:
@@ -60,3 +57,6 @@ integration-tests:
 	)
 
 tests: unit-tests integration-tests
+
+dist-clean:
+	rm -rf dist

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ archive_file_name="dss-plugin-${plugin_id}-${plugin_version}.zip"
 remote_url=`git config --get remote.origin.url`
 last_commit_id=`git rev-parse HEAD`
 
+.DEFAULT_GOAL := plugin
 
 dist-clean:
 	rm -rf dist
@@ -26,7 +27,7 @@ dev: dist-clean
 	@echo "[START] Archiving plugin to dist/ folder... (dev mode)"
 	@cat plugin.json | json_pp > /dev/null
 	@mkdir dist
-	@zip -v -9 dist/${archive_file_name} -r . --exclude "tests/*"
+	@zip -v -9 dist/${archive_file_name} -r . --exclude "tests/*" "env/*"
 	@echo "[SUCCESS] Archiving plugin to dist/ folder: Done!"
 
 unit-tests:


### PR DESCRIPTION
Adding a `make dev` so we can build local changes without committing
Tweaked the `plugin` target so if it is used (by copying) in projects with no tests yet the build does not fail with an error
